### PR TITLE
fix java 11 compatibility

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,7 @@
 {:deps
  {deercreeklabs/async-utils {:mvn/version "0.1.23"}
   deercreeklabs/baracus {:mvn/version "0.2.7"}
+  javax.xml.bind/jaxb-api {:mvn/version "2.4.0-b180830.0359"}
   org.java-websocket/Java-WebSocket {:mvn/version "1.5.2"}
   primitive-math/primitive-math {:mvn/version "0.1.6"}}
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>deercreeklabs</groupId>
   <artifactId>tube</artifactId>
-  <version>0.4.8</version>
+  <version>0.4.9</version>
   <name>tube</name>
   <description>A websocket client and server library</description>
   <url>https://github.com/deercreeklabs/tube</url>


### PR DESCRIPTION
java.xml.bind was removed in java 11 and we use it here for base64
parsing. See https://docs.oracle.com/en/java/javase/11/migrate/index.html#JSMIG-GUID-4B3D2D73-359C-4ADA-937E-BAEA79CFDF0F

I'm not sure if you are using java 8 or have something else going on making it work for you on 11+, let me know if I'm missing something.

